### PR TITLE
use Test::Requires to skip tests

### DIFF
--- a/t/02-check-jira.t
+++ b/t/02-check-jira.t
@@ -5,6 +5,7 @@ use strict;
 use warnings;
 use lib 't';
 use Test::More tests => 18;
+use Test::Requires qw/Jira::Client/;
 use File::Slurp;
 
 require "test-functions.pl";

--- a/t/02-check-log.t
+++ b/t/02-check-log.t
@@ -5,6 +5,7 @@ use strict;
 use warnings;
 use lib 't';
 use Test::More;
+use Test::Requires qw/Text::SpellChecker/;
 use File::Slurp;
 use File::Temp qw/tmpnam/;
 


### PR DESCRIPTION
had some problems with tests not skipping that should. The best way to handle this is to use Test::Requires. here's a patch that adds it.

As a side note I notice that you're using dzil (according to your metadata) but the branch that has your dist.ini isn't in your repo.

Signed-off-by: Caleb Cushing xenoterracide@gmail.com
