### PR TITLE
Fix handling of fully qualified module names for plugind

### DIFF
--- a/lib/Git/Hooks.pm
+++ b/lib/Git/Hooks.pm
@@ -453,7 +453,7 @@ sub _load_plugins {
                 # It must be a module name
 
                 ## no critic (ErrorHandling::RequireCheckingReturnValueOfEval, Modules::RequireBarewordIncludes)
-                eval {require "$prefix$plugin"};
+                eval "require $prefix$plugin";
                 ## use critic
 
             } else {


### PR DESCRIPTION
Currently using fully qualified module names as plugins doesn't seem to work.

To get automatic translation from module names to file names the argument to require needs to be a bareword. So the code would either need to use the stringy eval to get bareword handling or translate the module name into a filename itself.
