### PR TITLE
Remove the need to use File::Slurp in Makefile.PL. Using File::Slurp in ...

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,7 +1,6 @@
 use strict;
 use warnings;
 use File::Spec::Functions;
-use File::Slurp;
 
 ##{ $perl_prereq ? qq[use $perl_prereq;] : ''; ##}
 
@@ -95,7 +94,14 @@ EOF
     foreach my $inc (@inc) {
         my $git_pm = catfile($inc, 'Git.pm');
         if (-r $git_pm) {
-            write_file(catfile(qw/t GITPERLLIB/), $inc);
+            if(open my $gitperllib_fh, '>', catfile(qw/t GITPERLLIB/)) {
+               print $gitperllib_fh $inc;
+               close $gitperllib_fh;
+            }
+            else {
+               warn "Cannot open file '" . catfile(qw/t GITPERLLIB/) . "'!\n";
+               exit 0;
+            }
             warn <<"EOF";
 Hey, you're lucky. I just found it at:
 


### PR DESCRIPTION
Remove the need to use File::Slurp in Makefile.PL. Using File::Slurp in Makefile.PL creates a dependency problem because it is used before the dependencies are solved.

I have had trouble with installing Git::Hooks using plenv, local directory perl and carton. I have Git::Hooks in my cpanfile. Git::Hooks uses File::Slurp in customized Makefile.PL but File::Slurp is not part of Perl Core Modules. To go around the situation, I have had to first install File::Slurp into (plenv) system wide Perl, and only then Carton manages to install Git::Hooks locally (in my local directory's subdirectory 'local'. In our setup, it is important that all Git::Hooks related modules stay in local directory.
