### PR TITLE
Fix handling of multiple anon subs for the same hook

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,12 @@ Revision history for perl module Git-Hooks. -*- text -*-
 
 {{$NEXT}}
 
+  [Fixes]
+
+  - (PR#37) Specifying multiple anonymous subs for the same hooks did not
+    work. Only the first sub that was defined would actually be called. Fixed
+    by Dave Rolsky.
+
 1.15.1    2017-03-02 14:26:16-03:00 America/Sao_Paulo
 
   [Changes]

--- a/lib/Git/Hooks.pm
+++ b/lib/Git/Hooks.pm
@@ -29,9 +29,8 @@ BEGIN {                         ## no critic (RequireArgUnpacking)
         $hook =~ tr/_/-/;
         no strict 'refs';       ## no critic (ProhibitNoStrict)
         *{__PACKAGE__ . '::' . $installer} = sub (&) {
-            my ($foo) = @_;
-            my $subname = subname($foo);
-            $Hooks{$hook}{$subname} ||= sub { $foo->(@_); };
+            my ($sub) = @_;
+            push @{$Hooks{$hook}}, sub { $sub->(@_); };
         }
     }
 
@@ -645,8 +644,8 @@ sub run_hook {                  ## no critic (Subroutines::ProhibitExcessComplex
     my $errors = 0;             # Count number of errors found
 
     # Call every hook function installed by the hook scripts before.
-    while (my ($subname, $hook) = each %{$Hooks{$hook_name}}) {
-        my ($package) = $subname =~ m/^(.+)::/;
+    for my $hook (@{$Hooks{$hook_name}}) {
+        my ($package) = subname($hook) =~ m/^(.+)::/;
         my $ok = eval { $hook->($git, @args) };
         if (defined $ok) {
             # Modern hooks return a boolean value indicating their success.


### PR DESCRIPTION
Storing these in a hash keyed on sub name doesn't work because all anon subs
are named __ANON__.