### PR TITLE
Fix bug in running 'git log'

### DIFF
--- a/lib/Git/Hooks/CheckCommit.pm
+++ b/lib/Git/Hooks/CheckCommit.pm
@@ -226,7 +226,7 @@ sub signature_errors {
     my $signature = $git->get_config($CFG => 'signature');
 
     if (defined $signature && $signature ne 'nocheck') {
-        my $status = $git->run(qw/log -1 --format='%G?'/, $commit);
+        my $status = $git->run(qw/log -1 --format=%G?/, $commit);
 
         if ($status eq 'B') {
             $git->fault(<<'EOS', {commit => $commit, option => 'signature'});

--- a/lib/Git/Hooks/CheckCommit.pm
+++ b/lib/Git/Hooks/CheckCommit.pm
@@ -226,7 +226,7 @@ sub signature_errors {
     my $signature = $git->get_config($CFG => 'signature');
 
     if (defined $signature && $signature ne 'nocheck') {
-        my $status = $git->run(qw/log -1 --format='%G?'/, $commit->commit);
+        my $status = $git->run(qw/log -1 --format='%G?'/, $commit);
 
         if ($status eq 'B') {
             $git->fault(<<'EOS', {commit => $commit, option => 'signature'});


### PR DESCRIPTION
$git->run(qw/log -1 --format='%G?'/, $commit->commit);
results in:
'letter' (with single quotation marks),
not in plain letter.

Signed-off-by: Mikko Koivunalho <mikko.koivunalho@iki.fi>