### PR TITLE
Add a way to access githooks.userenv value

### DIFF
--- a/lib/Git/Hooks.pm
+++ b/lib/Git/Hooks.pm
@@ -1093,7 +1093,11 @@ sign, you can configure it like this:
       'eval:(exists $ENV{GERRIT_USER_EMAIL} && $ENV{GERRIT_USER_EMAIL} =~ /([^@]+)/) ? $1 : undef'
 
 This variable is useful for any hook that need to authenticate the
-user performing the git action.
+user performing the git action. The value is available
+in L<Git::Hooks::CheckReference> hook
+when specifying allowed reference (branch) names with config item acl,
+see L<Git::Hooks::CheckReference/"grok_acls CFG ACTIONS">.
+It can be access by string '{AUTHENTICATED-USER}'.
 
 =head2 admin USERSPEC
 

--- a/lib/Git/Hooks/CheckReference.pm
+++ b/lib/Git/Hooks/CheckReference.pm
@@ -152,7 +152,13 @@ may configure it in a Git configuration file like this:
     acl = allow CRUD ^refs/tags/ by @cms
 
     # Users may maintain personal branches under user/<username>/
+    # All environment variables are available.
+    # Just surround them with '{' and '}'.
     acl = allow CRUD ^refs/heads/user/{USER}/
+
+    # The authenticated user, as provided by config item githooks.userenv,
+    # is available via the special string '{AUTHENTICATED-USER}'.
+    acl = allow CRUD ^refs/heads/user/{Git::Hooks-Auth-User}/
 
     # Users may only update the vetted branch names
     acl = allow U    ^refs/heads/(?:feature|release|hotfix)/

--- a/lib/Git/Repository/Plugin/GitHooks.pm
+++ b/lib/Git/Repository/Plugin/GitHooks.pm
@@ -1562,6 +1562,9 @@ sub grok_acls {
             $acl{action} = $2;
             my $spec     = $3;
 
+            # Interpolate authenticated user. In case user was fetched
+            # by eval, not by env var! See: config item githooks.userenv
+            $spec =~ s/{AUTHENTICATED-USER}/$git->authenticated_user()/ige;
             # Interpolate environment variables embedded as "{VAR}".
             $spec =~ s/{(\w+)}/$ENV{$1}/ige;
             # Pre-compile regex
@@ -2279,6 +2282,10 @@ Before being interpreted as a string or as a regexp, any sub-string of it in the
 form C<{VAR}> is replaced by C<$ENV{VAR}>. This is useful, for example, to
 interpolate the committer's username in the spec, in order to create personal
 name spaces for users.
+
+The authenticated user, as provided by config var C<githooks.userenv>,
+see L<Git::Hooks/"userenv STRING">,
+is available via the special string '{AUTHENTICATED-USER}'.
 
 (See the documentation of the C<acl> option in the L<Git::Hooks::CheckFile> and
 the L<Git::Hooks::CheckReference> plugins for examples things as files and


### PR DESCRIPTION
Config item githooks.userenv is used to name an environmental variable
which provides the authenticated user name. This is normally
USER when accessing repo via SSH or REMOTE_USER when using
a webserver.
When it is not possible to just name an environmental variable,
the value can be generated by a perl sentence.
In such a case, the value should be available for use in
other configurations, e.g. CheckReference acls.

This change is more controversial. I tried to pick a name that would never clash with a real environmental variable.
Of course, the name can be changed.

Signed-off-by: Mikko Koivunalho <mikko.koivunalho@iki.fi>