### PR TITLE
Fix bug: return nr of errors, not boolean

### DIFF
--- a/lib/Git/Hooks/CheckLog.pm
+++ b/lib/Git/Hooks/CheckLog.pm
@@ -321,7 +321,7 @@ sub check_ref {
         $errors += message_errors($git, $commit, $commit->message);
     }
 
-    return $errors == 0;
+    return $errors;
 }
 
 sub check_patchset {


### PR DESCRIPTION
We are returning positive value when there are no errors.
We should instead return the number of errors.
A positive value means that one or more checks failed.

Signed-off-by: Mikko Johannes Koivunalho <mikko.koivunalho@iki.fi>