### PR TITLE
Fix bug: pass commit as hash string, not object

### DIFF
--- a/lib/Git/Hooks/CheckCommit.pm
+++ b/lib/Git/Hooks/CheckCommit.pm
@@ -225,7 +225,7 @@ sub signature_errors {
     my $signature = $git->get_config($CFG => 'signature');
 
     if (defined $signature && $signature ne 'nocheck') {
-        my $status = $git->run(qw/log -1 --format=%G?/, $commit);
+        my $status = $git->run(qw/log -1 --format=%G?/, $commit->commit);
 
         if ($status eq 'B') {
             $git->fault(<<'EOS', {commit => $commit, option => 'signature'});


### PR DESCRIPTION
Git::Repository::run() does not interpret Git::Repository::Log objects
into strings (commit hash string). We need to do this when we pass
commits to Git command line.

Signed-off-by: Mikko Johannes Koivunalho <mikko.koivunalho@iki.fi>