### PR TITLE
Fix bug: CheckCommit commit object

### DIFF
--- a/lib/Git/Hooks/CheckCommit.pm
+++ b/lib/Git/Hooks/CheckCommit.pm
@@ -225,7 +225,7 @@ sub signature_errors {
     my $signature = $git->get_config($CFG => 'signature');
 
     if (defined $signature && $signature ne 'nocheck') {
-        my $status = $git->run(qw/log -1 --format=%G?/, $commit->commit);
+        my $status = $git->run(qw/log -1 --format=%G?/, $commit);
 
         if ($status eq 'B') {
             $git->fault(<<'EOS', {commit => $commit, option => 'signature'});

--- a/lib/Git/Hooks/CheckCommit.pm
+++ b/lib/Git/Hooks/CheckCommit.pm
@@ -9,6 +9,7 @@ use Carp;
 use Log::Any '$log';
 use Git::Hooks;
 use Git::Repository::Log;
+use Git::Repository::Log::Iterator;
 use List::MoreUtils qw/any none/;
 
 my $PKG = __PACKAGE__;
@@ -225,7 +226,7 @@ sub signature_errors {
     my $signature = $git->get_config($CFG => 'signature');
 
     if (defined $signature && $signature ne 'nocheck') {
-        my $status = $git->run(qw/log -1 --format=%G?/, $commit);
+        my $status = $git->run(qw/log -1 --format=%G?/, $commit->commit());
 
         if ($status eq 'B') {
             $git->fault(<<'EOS', {commit => $commit, option => 'signature'});
@@ -395,7 +396,8 @@ sub check_post_commit {
 
     return 1 unless $git->is_reference_enabled($current_branch);
 
-    my $commit = $git->get_sha1('HEAD');
+    my $iter = Git::Repository::Log::Iterator->new($git->get_sha1('HEAD'));
+    my $commit = $iter->next();
 
     return signature_errors($git, $commit);
 }

--- a/lib/Git/Hooks/CheckCommit.pm
+++ b/lib/Git/Hooks/CheckCommit.pm
@@ -478,7 +478,7 @@ committer identities.
 =item * B<post-commit>, B<post-applypatch>
 
 This hook is invoked after a commit is made to check its signature. Note
-that the commit is checked after is has been made and any errors must be
+that the commit is checked after it has been made and any errors must be
 fixed with a C<git-commit --amend> command afterwards.
 
 =item * B<update>

--- a/lib/Git/Hooks/CheckCommit.pm
+++ b/lib/Git/Hooks/CheckCommit.pm
@@ -463,6 +463,10 @@ may configure it in a Git configuration file like this:
     # avoid careless pushes.
     push-limit = 2
 
+    # Reject commits unless they are signed with a GPG key
+    # and the signature is good (does not need to be trusted).
+    signature = good
+
 =head1 DESCRIPTION
 
 This L<Git::Hooks> plugin hooks itself to the hooks below to enforce commit


### PR DESCRIPTION
The earlier PR https://github.com/gnustavo/Git-Hooks/pull/69 introduced a new problem because the `check_post_commit()` subroutine was passing the commit parameter as a hash. To fix both problems, I reverted the earlier fix and changed now both subroutines `check_post_commit()` and `signature_errors()`.

I also created a test. It is unfortunately somewhat complicated and prone to break as it depends on a peculiarity of `gpg` program, possibly a bug. I tested with an earlier version of `gpg` and I could not run the test successfully. But with gpg version 2.2.27 the tests work. If the local version of `gpg` is not suitable, the tests will skip that part and the test suite will not fail. It tests signature in  both post-commit (client) and update (server) hooks.