### PR TITLE
Fix bug: return correctly from sub

### DIFF
--- a/lib/Git/Hooks/CheckWhitespace.pm
+++ b/lib/Git/Hooks/CheckWhitespace.pm
@@ -17,7 +17,7 @@ sub check_ref {
     my ($old_commit, $new_commit) = $git->get_affected_ref_range($ref);
 
     # If the reference is being deleted we have nothing to check
-    next if $new_commit eq $git->undef_commit;
+    return 0 if $new_commit eq $git->undef_commit;
 
     # If the reference is being created we have to calculate a proper
     # $old_commit to diff against.
@@ -27,7 +27,7 @@ sub check_ref {
         while (my $log = $log_iterator->next()) {
             $last_log = $log;
         }
-        next unless $last_log;
+        return 0 unless $last_log;
         my @parents = $last_log->parent;
         if (@parents == 0) {
             # We reached the repository root. Hence, let's consider


### PR DESCRIPTION
I was getting errors like this in Git when I pushed to remote host:

    remote: Exiting subroutine via next at [..]/local/lib/perl5/Git/Hooks/CheckWhitespace.pm line 30.

The command `next` should not be used to return from a sub.

    [..]
    next cannot return a value from a block that typically returns a value,
    such as eval {}, sub {}, or do {}. It will perform its flow control
    behavior, which precludes any return value. It should not be used
    to exit a grep or map operation.
    [Perldoc function next, https://perldoc.perl.org/functions/next]

Signed-off-by: Mikko Johannes Koivunalho <mikko.koivunalho@iki.fi>