### PR TITLE
Feature: OR-ed plugins

### DIFF
--- a/lib/Git/Hooks.pm
+++ b/lib/Git/Hooks.pm
@@ -1278,6 +1278,13 @@ is useful if you want to enable a plugin globally and only disable it for some
 repositories. You can even re-enable it later, if you want, by mentioning it
 again without the prefix.
 
+Plugins can be OR-ed by separating them with a pipe (C<|>) instead of a space.
+
+    [githooks]
+      plugin = CheckFile|CheckJira
+
+In this case either CheckFile C<OR> CheckJira has to match.
+
 =head2 [DEPRECATED after v3.3.0] disable PLUGIN...
 
 B<This option is deprecated.> Please, use the C<githooks.plugin> option with an

--- a/lib/Git/Hooks.pm
+++ b/lib/Git/Hooks.pm
@@ -1281,9 +1281,9 @@ again without the prefix.
 Plugins can be OR-ed by separating them with a pipe (C<|>) instead of a space.
 
     [githooks]
-      plugin = CheckFile|CheckJira
+      plugin = CheckFile|CheckJira CheckWhitespace
 
-In this case either CheckFile C<OR> CheckJira has to match.
+In this case CheckWhitespace C<AND> either CheckFile C<OR> CheckJira has to match.
 
 =head2 [DEPRECATED after v3.3.0] disable PLUGIN...
 

--- a/lib/Git/Repository/Plugin/GitHooks.pm
+++ b/lib/Git/Repository/Plugin/GitHooks.pm
@@ -891,10 +891,10 @@ sub fail_on_faults {
         $faults .= "\n" unless $faults =~ /\n$/;
         if ($warn_only) {
             $log->warning(Warning => {faults => $faults});
-            carp $faults;
+            warn $faults;
         } else {
             $log->error(Error => {faults => $faults});
-            croak $faults;
+            die $faults;
         }
     }
 

--- a/lib/Git/Repository/Plugin/GitHooks.pm
+++ b/lib/Git/Repository/Plugin/GitHooks.pm
@@ -864,7 +864,7 @@ sub get_faults {
     # If any parts of the condition don't have an 'OK', they've failed and we need to deny the commit
     if (grep {!/\(ok\)/} @conditions) {
         $faults .= join("\n\n", map {$_->{msg}} @{$git->{_plugin_githooks}{faults}});
-        $faults .= join(" ", "\n\nOur configured plugins as they were evaluated:\n", @conditions, "\n\n");
+        $faults .= "\n\nOur configured plugins as they were evaluated:\n" . join(" ", @conditions) . "\n\n";
     }
 
     if ($git->{_plugin_githooks}{hookname} =~ /^commit-msg|pre-commit$/

--- a/lib/Git/Repository/Plugin/GitHooks.pm
+++ b/lib/Git/Repository/Plugin/GitHooks.pm
@@ -862,7 +862,7 @@ sub get_faults {
     }
 
     # If any parts of the condition are empty they have failed and we should return all faults
-    if (grep {/^(\|*)$/} @condition) {
+    if (grep {/^\|*$/} @condition) {
         $faults .= join("\n\n", @{$git->{_plugin_githooks}{faults}});
     }
 

--- a/lib/Git/Repository/Plugin/GitHooks.pm
+++ b/lib/Git/Repository/Plugin/GitHooks.pm
@@ -856,9 +856,9 @@ sub get_faults {
     my @condition = split(" ", $git->get_config(githooks => 'plugin'));
 
     foreach (@{$git->{_plugin_githooks}{faults}}) {
-        my $plugin = '';
-        ($plugin) = $_ =~ /.*Git::Hooks::(\w+):.*/;
-        map {s/$plugin//} @condition;
+        my $origin = '';
+        ($origin) = $_ =~ /.*Git::Hooks::(\w+):.*/;
+        map {s/$origin//} @condition;
     }
 
     # If any parts of the condition are empty they have failed and we should return all faults


### PR DESCRIPTION
Fixes #76 
Fixes #58 (CheckLog could be OR-ed with CheckJira)

Plugins separated by a pipe, will be OR-ed. This is in addition to, and can be combined with, the existing behaviour where any individually define plugins all need to match.

All defined plugins will be executed, and in the end we evaluate if any such "conditions" have failed.